### PR TITLE
Migrate to ES Module Syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ async function externalEvaluation(claims) {
 
 export default {
 	async fetch(request, env, ctx) {
-		// return new Response('Hello World From My First Worker!');
     if (request.url.endsWith('keys')) {
       return handleKeysRequest(env)
     } else {

--- a/index.js
+++ b/index.js
@@ -10,13 +10,16 @@ async function externalEvaluation(claims) {
 // EVERYTHING PAST THIS SHOULD NOT NEED TO CHANGE UNLESS YOU WANT TO
 // ==================================================================
 
-addEventListener('fetch', event => {
-  if (event.request.url.endsWith('keys')) {
-    event.respondWith(handleKeysRequest(event))
-  } else {
-    event.respondWith(handleExternalEvaluationRequest(event))
-  }
-})
+export default {
+	async fetch(request, env, ctx) {
+		// return new Response('Hello World From My First Worker!');
+    if (request.url.endsWith('keys')) {
+      return handleKeysRequest(env)
+    } else {
+      return handleExternalEvaluationRequest(request, env)
+    }
+  },
+}
 
 // the key in KV that holds the generated signing keys
 const KV_SIGNING_KEY = 'external_auth_keys'
@@ -73,10 +76,11 @@ function asciiToUint8Array(str) {
 /**
  * Helper to get the Access public keys from the certs endpoint
  * @param {*} kid - The key id that signed the token
+ * @param {*} env
  * @returns
  */
-async function fetchAccessPublicKey(kid) {
-  const resp = await fetch(`https://${TEAM_DOMAIN}/cdn-cgi/access/certs`)
+async function fetchAccessPublicKey(kid, env) {
+  const resp = await fetch(`https://${env.TEAM_DOMAIN}/cdn-cgi/access/certs`)
   const keys = await resp.json()
   const jwk = keys.keys.filter(key => key.kid == kid)[0]
   const key = await crypto.subtle.importKey(
@@ -94,9 +98,10 @@ async function fetchAccessPublicKey(kid) {
 
 /**
  * Generate a key pair and stores them into Workers KV for future use
+ * @param {*} env
  * @returns
  */
-async function generateKeys() {
+async function generateKeys(env) {
   console.log('generating a new signing key pair')
   try {
     const keypair = await crypto.subtle.generateKey(
@@ -112,7 +117,7 @@ async function generateKeys() {
     const publicKey = await crypto.subtle.exportKey('jwk', keypair.publicKey)
     const privateKey = await crypto.subtle.exportKey('jwk', keypair.privateKey)
     const kid = await generateKID(JSON.stringify(publicKey))
-    await KV.put(
+    await env.KV.put(
       KV_SIGNING_KEY,
       JSON.stringify({ public: publicKey, private: privateKey, kid: kid }),
     )
@@ -125,10 +130,11 @@ async function generateKeys() {
 
 /**
  * Load the signing key from KV
+ * @param {*} env
  * @returns
  */
-async function loadSigningKey() {
-  const keyset = await KV.get(KV_SIGNING_KEY, 'json')
+async function loadSigningKey(env) {
+  const keyset = await env.KV.get(KV_SIGNING_KEY, 'json')
   if (keyset) {
     const signingKey = await crypto.subtle.importKey(
       'jwk',
@@ -149,27 +155,29 @@ async function loadSigningKey() {
 
 /**
  * Get the public key in JWK format
+ * @param {*} env
  * @returns
  */
-async function loadPublicKey() {
+async function loadPublicKey(env) {
   // if the JWK values are already in KV then just return that
-  const key = await KV.get(KV_SIGNING_KEY, 'json')
+  const key = await env.KV.get(KV_SIGNING_KEY, 'json')
   if (key) {
     return { kid: key.kid, ...key.public }
   }
 
   // otherwise generate keys and store the Keyset in KV
-  const { kid, publicKey } = await generateKeys()
+  const { kid, publicKey } = await generateKeys(env)
   return { kid, ...publicKey }
 }
 
 /**
  * Turn a payload into a JWT
  * @param {*} payload
+ * @param {*} env
  * @returns
  */
-async function signJWT(payload) {
-  const { kid, privateKey } = await loadSigningKey()
+async function signJWT(payload, env) {
+  const { kid, privateKey } = await loadSigningKey(env)
   const header = {
     alg: 'RS256',
     kid: kid,
@@ -217,14 +225,15 @@ function parseJWT(token) {
  * Validates the provided token using the Access public key set
  *
  * @param token - the token to be validated
+ * @param env
  * @returns {object} Returns the payload if valid, or throws an error if not
  */
-async function verifyToken(token) {
-  if (DEBUG) {
+async function verifyToken(token, env) {
+  if (env.DEBUG) {
     console.log('incoming JWT', token)
   }
   const jwt = parseJWT(token)
-  const key = await fetchAccessPublicKey(jwt.header.kid)
+  const key = await fetchAccessPublicKey(jwt.header.kid, env)
 
   const verified = await crypto.subtle.verify(
     'RSASSA-PKCS1-v1_5',
@@ -249,11 +258,11 @@ async function verifyToken(token) {
 
 /**
  * Top level handler for public jwks endpoint
- * @param {*} event
+ * @param {*} env
  * @returns
  */
-async function handleKeysRequest(event) {
-  const keys = await loadPublicKey()
+async function handleKeysRequest(env) {
+  const keys = await loadPublicKey(env)
   return new Response(JSON.stringify({ keys: [keys] }), {
     status: 200,
     headers: { 'content-type': 'application/json' },
@@ -262,15 +271,16 @@ async function handleKeysRequest(event) {
 
 /**
  * Top level handler for external evaluation requests
- * @param {*} event
+ * @param {*} request
+ * @param {*} env
  * @returns
  */
-async function handleExternalEvaluationRequest(event) {
+async function handleExternalEvaluationRequest(request, env) {
   const now = Math.round(Date.now() / 1000)
   let result = { success: false, iat: now, exp: now + 60 }
   try {
-    const body = await event.request.json()
-    const claims = await verifyToken(body.token)
+    const body = await request.json()
+    const claims = await verifyToken(body.token, env)
 
     if (claims) {
       result.nonce = claims.nonce
@@ -279,8 +289,8 @@ async function handleExternalEvaluationRequest(event) {
       }
     }
 
-    const jwt = await signJWT(result)
-    if (DEBUG) {
+    const jwt = await signJWT(result, env)
+    if (env.DEBUG) {
       console.log('outgoing JWT', jwt)
     }
     return new Response(JSON.stringify({ token: jwt }), {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ main = "index.js"
 
 [[kv_namespaces]]
 binding = "KV"
-id = "<fill-in>"
+id = "<update>"
 
 [vars]
 TEAM_DOMAIN="<update>.cloudflareaccess.com"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,13 +1,11 @@
 name = "external-auth-rule-eval"
-account_id = "<fill in>"
 workers_dev = true
-compatibility_date = "2022-06-10"
+compatibility_date = "2024-08-06"
 main = "index.js"
 
-kv_namespaces = [
-    # namespace: 
-  { binding = "KV", id = "<fill in>", preview_id = "<fill in>" },
-]
+[[kv_namespaces]]
+binding = "KV"
+id = "<fill-in>"
 
 [vars]
 TEAM_DOMAIN="<update>.cloudflareaccess.com"


### PR DESCRIPTION
This change was inspired by the fact that I am building a demo of the External Evaluation rules feature. The goal is to update the sample GitHub repository and related documentation, create a reference architecture diagram, and demoable solution. 

I followed this guide (https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/) to migrate existing Workers to the new ES Modules format.

I also have a Draft PR to update the documentation based on these changes. Preview URL: https://84ca385c.cloudflare-docs-7ou.pages.dev/cloudflare-one/policies/access/external-evaluation/